### PR TITLE
Added `assignee_changed` issue events

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,14 @@
 # History
 
+## 2018-08-08
+
+- Adding `assignee_changed` events
+- Minor bug fix (use `reset` instead of `init` now)
+
+## 2018-08-03
+
+- Deployed on JobTeaser's Kubernetes development cluster. Took me less than 2 hours, from scratch. With the help of Gearnode :) Yey!
+
 ## 2018-07-29
 
 - Enabled deployment to Heroku. Added `dep` as dependency manager. Abandoned deployment to Heroku because it doesn't seem usable from the Scheduler plugin that is needed to schedule task executions.

--- a/Makefile
+++ b/Makefile
@@ -16,3 +16,6 @@ push:
 
 clean:
 	rm -rf $(DOCKER_BUILD)
+
+test:
+	go test -v -covermode=count -coverprofile=coverage.out ./...

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ For now, the following events are generated from the issue's data:
 - `created`
 - `comment_added`
 - `status_changed`
+- `assignee_changed`
 
 If you want to add new kinds of events:
 

--- a/store/mockstore.go
+++ b/store/mockstore.go
@@ -112,6 +112,20 @@ func (m *MockStore) ReplaceIssueStateAndEvents(ik string, is IssueState, ies []I
 				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeTo=`%v` but was expecting `%v`\n", i, *ie.StatusChangeTo, *eie.StatusChangeTo)
 			}
 		}
+		if eie.AssigneeChangeFrom != nil {
+			if ie.AssigneeChangeFrom == nil {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeFrom=nil but was expecting `%v`\n", i, *eie.AssigneeChangeFrom)
+			} else if *ie.AssigneeChangeFrom != *eie.AssigneeChangeFrom {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeFrom=`%v` but was expecting `%v`\n", i, *ie.AssigneeChangeFrom, *eie.AssigneeChangeFrom)
+			}
+		}
+		if eie.AssigneeChangeTo != nil {
+			if ie.AssigneeChangeTo == nil {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeTo=nil but was expecting `%v`\n", i, *eie.AssigneeChangeTo)
+			} else if *ie.AssigneeChangeTo != *eie.AssigneeChangeTo {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeTo=`%v` but was expecting `%v`\n", i, *ie.AssigneeChangeTo, *eie.AssigneeChangeTo)
+			}
+		}
 	}
 
 	return ee.err

--- a/store/mockstore.go
+++ b/store/mockstore.go
@@ -73,61 +73,61 @@ func (m *MockStore) ReplaceIssueStateAndEvents(ik string, is IssueState, ies []I
 
 	// Check count of events
 	if len(ies) != len(ee.issueEvents) {
-		m.Errorf("mock received `ReplaceIssueStateAndEvents` with %d events but was expecting %d\n", len(ies), len(ee.issueEvents))
-	}
+		m.Errorf("mock received `ReplaceIssueStateAndEvents` with %d events but was expecting %d (%v)\n", len(ies), len(ee.issueEvents), ies)
+	} else {
 
-	// Check events
-	for i, ie := range ies {
-		eie := ee.issueEvents[i]
-		if ie.EventTime != eie.EventTime {
-			m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].EventTime=`%v` but was expecting `%v`\n", i, ie.EventTime, eie.EventTime)
-		}
-		if ie.EventKind != eie.EventKind {
-			m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].EventKind=`%v` but was expecting `%v`\n", i, ie.EventKind, eie.EventKind)
-		}
-		if ie.EventAuthor != eie.EventAuthor {
-			m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].EventAuthor=`%v` but was expecting `%v`\n", i, ie.EventAuthor, eie.EventAuthor)
-		}
-		if ie.IssueKey != eie.IssueKey {
-			m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].IssueKey=`%v` but was expecting `%v`\n", i, ie.IssueKey, eie.IssueKey)
-		}
-		if eie.CommentBody != nil {
-			if ie.CommentBody == nil {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].CommentBody=nil but was expecting `%v`\n", i, *eie.CommentBody)
-			} else if *ie.CommentBody != *eie.CommentBody {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].CommentBody=`%v` but was expecting `%v`\n", i, *ie.CommentBody, *eie.CommentBody)
+		// Check events
+		for i, ie := range ies {
+			eie := ee.issueEvents[i]
+			if !timesAlmostEqual(ie.EventTime, eie.EventTime) {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].EventTime=`%v` but was expecting `%v`\n", i, ie.EventTime, eie.EventTime)
 			}
-		}
-		if eie.StatusChangeFrom != nil {
-			if ie.StatusChangeFrom == nil {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeFrom=nil but was expecting `%v`\n", i, *eie.StatusChangeFrom)
-			} else if *ie.StatusChangeFrom != *eie.StatusChangeFrom {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeFrom=`%v` but was expecting `%v`\n", i, *ie.StatusChangeFrom, *eie.StatusChangeFrom)
+			if ie.EventKind != eie.EventKind {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].EventKind=`%v` but was expecting `%v`\n", i, ie.EventKind, eie.EventKind)
 			}
-		}
-		if eie.StatusChangeTo != nil {
-			if ie.StatusChangeTo == nil {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeTo=nil but was expecting `%v`\n", i, *eie.StatusChangeTo)
-			} else if *ie.StatusChangeTo != *eie.StatusChangeTo {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeTo=`%v` but was expecting `%v`\n", i, *ie.StatusChangeTo, *eie.StatusChangeTo)
+			if ie.EventAuthor != eie.EventAuthor {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].EventAuthor=`%v` but was expecting `%v`\n", i, ie.EventAuthor, eie.EventAuthor)
 			}
-		}
-		if eie.AssigneeChangeFrom != nil {
-			if ie.AssigneeChangeFrom == nil {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeFrom=nil but was expecting `%v`\n", i, *eie.AssigneeChangeFrom)
-			} else if *ie.AssigneeChangeFrom != *eie.AssigneeChangeFrom {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeFrom=`%v` but was expecting `%v`\n", i, *ie.AssigneeChangeFrom, *eie.AssigneeChangeFrom)
+			if ie.IssueKey != eie.IssueKey {
+				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].IssueKey=`%v` but was expecting `%v`\n", i, ie.IssueKey, eie.IssueKey)
 			}
-		}
-		if eie.AssigneeChangeTo != nil {
-			if ie.AssigneeChangeTo == nil {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeTo=nil but was expecting `%v`\n", i, *eie.AssigneeChangeTo)
-			} else if *ie.AssigneeChangeTo != *eie.AssigneeChangeTo {
-				m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeTo=`%v` but was expecting `%v`\n", i, *ie.AssigneeChangeTo, *eie.AssigneeChangeTo)
+			if eie.CommentBody != nil {
+				if ie.CommentBody == nil {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].CommentBody=nil but was expecting `%v`\n", i, *eie.CommentBody)
+				} else if *ie.CommentBody != *eie.CommentBody {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].CommentBody=`%v` but was expecting `%v`\n", i, *ie.CommentBody, *eie.CommentBody)
+				}
+			}
+			if eie.StatusChangeFrom != nil {
+				if ie.StatusChangeFrom == nil {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeFrom=nil but was expecting `%v`\n", i, *eie.StatusChangeFrom)
+				} else if *ie.StatusChangeFrom != *eie.StatusChangeFrom {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeFrom=`%v` but was expecting `%v`\n", i, *ie.StatusChangeFrom, *eie.StatusChangeFrom)
+				}
+			}
+			if eie.StatusChangeTo != nil {
+				if ie.StatusChangeTo == nil {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeTo=nil but was expecting `%v`\n", i, *eie.StatusChangeTo)
+				} else if *ie.StatusChangeTo != *eie.StatusChangeTo {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].StatusChangeTo=`%v` but was expecting `%v`\n", i, *ie.StatusChangeTo, *eie.StatusChangeTo)
+				}
+			}
+			if eie.AssigneeChangeFrom != nil {
+				if ie.AssigneeChangeFrom == nil {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeFrom=nil but was expecting `%v`\n", i, *eie.AssigneeChangeFrom)
+				} else if *ie.AssigneeChangeFrom != *eie.AssigneeChangeFrom {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeFrom=`%v` but was expecting `%v`\n", i, *ie.AssigneeChangeFrom, *eie.AssigneeChangeFrom)
+				}
+			}
+			if eie.AssigneeChangeTo != nil {
+				if ie.AssigneeChangeTo == nil {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeTo=nil but was expecting `%v`\n", i, *eie.AssigneeChangeTo)
+				} else if *ie.AssigneeChangeTo != *eie.AssigneeChangeTo {
+					m.Errorf("mock received `ReplaceIssueStateAndEvents` with event[%d].AssigneeChangeTo=`%v` but was expecting `%v`\n", i, *ie.AssigneeChangeTo, *eie.AssigneeChangeTo)
+				}
 			}
 		}
 	}
-
 	return ee.err
 }
 
@@ -294,4 +294,8 @@ func (m *MockStore) popExpectedReplaceIssueStateAndEventsForIssueKey(ik string) 
 	}
 
 	return nil
+}
+
+func timesAlmostEqual(t1 time.Time, t2 time.Time) bool {
+	return t1.Sub(t2) < time.Millisecond
 }

--- a/store/pgstore.go
+++ b/store/pgstore.go
@@ -125,7 +125,9 @@ func (s *PGStore) CreateTables() {
 			"issue_fix_versions" TEXT,
 			"comment_body" TEXT,
 			"status_change_from" TEXT,
-			"status_change_to" TEXT
+			"status_change_to" TEXT,
+			"assignee_change_from" TEXT,
+			"assignee_change_to" TEXT
 		);`,
 	}
 	err := s.exec(queries)
@@ -170,6 +172,8 @@ func insertIssueEvent(tx *sql.Tx, ie IssueEvent, is IssueState) (err error) {
 		comment_body,
 		status_change_from,
 		status_change_to,
+		assignee_change_from,
+		assignee_change_to,
 		issue_key,
 		issue_created_at,
 		issue_updated_at,
@@ -192,7 +196,7 @@ func insertIssueEvent(tx *sql.Tx, ie IssueEvent, is IssueState) (err error) {
 		issue_components,
 		issue_fix_versions
 	)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27);
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21, $22, $23, $24, $25, $26, $27, $28, $29);
 	`
 
 	_, err = tx.Exec(
@@ -203,6 +207,8 @@ func insertIssueEvent(tx *sql.Tx, ie IssueEvent, is IssueState) (err error) {
 		ie.CommentBody,
 		ie.StatusChangeFrom,
 		ie.StatusChangeTo,
+		ie.AssigneeChangeFrom,
+		ie.AssigneeChangeTo,
 		ie.IssueKey,
 		is.CreatedAt,
 		is.UpdatedAt,

--- a/store/store.go
+++ b/store/store.go
@@ -42,11 +42,13 @@ type IssueState struct {
 // IssueEvent represents a change event on an issue to be stored
 // in the DB.
 type IssueEvent struct {
-	EventTime        time.Time
-	EventKind        string
-	EventAuthor      string
-	IssueKey         string
-	CommentBody      *string
-	StatusChangeFrom *string
-	StatusChangeTo   *string
+	EventTime          time.Time
+	EventKind          string
+	EventAuthor        string
+	IssueKey           string
+	CommentBody        *string
+	StatusChangeFrom   *string
+	StatusChangeTo     *string
+	AssigneeChangeFrom *string
+	AssigneeChangeTo   *string
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -57,8 +57,10 @@ func TestPGStore_ReplaceIssueStateAndEvents(t *testing.T) {
 		"kind",
 		"author",
 		"comment",
-		"from",
-		"to",
+		"status_from",
+		"status_to",
+		"assignee_from",
+		"assignee_to",
 		"key",
 		anyTime{},
 		anyTime{},
@@ -178,13 +180,15 @@ func mockIssueState() store.IssueState {
 
 func mockIssueEvent() store.IssueEvent {
 	return store.IssueEvent{
-		EventTime:        time.Now(),
-		EventKind:        "kind",
-		EventAuthor:      "author",
-		IssueKey:         "key",
-		CommentBody:      stringAddr("comment"),
-		StatusChangeFrom: stringAddr("from"),
-		StatusChangeTo:   stringAddr("to"),
+		EventTime:          time.Now(),
+		EventKind:          "kind",
+		EventAuthor:        "author",
+		IssueKey:           "key",
+		CommentBody:        stringAddr("comment"),
+		StatusChangeFrom:   stringAddr("status_from"),
+		StatusChangeTo:     stringAddr("status_to"),
+		AssigneeChangeFrom: stringAddr("assignee_from"),
+		AssigneeChangeTo:   stringAddr("assignee_to"),
 	}
 }
 


### PR DESCRIPTION
- From the issue's changelog, when the field changed is `assignee`,
create an `assignee_changed` event.
- `assignee_change_from` and `assignee_change_to` fields have been added to
`jira_issues_events`.

Fixes #18 