### PR TITLE
Continuing sync

### DIFF
--- a/jira/client/apiclient.go
+++ b/jira/client/apiclient.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/andygrunwald/go-jira"
 )
@@ -59,15 +60,15 @@ func (c *APIClient) SearchIssues(query string, issueKeys chan string) {
 // GetIssue fetches the issue specified by the key from the Jira
 // API using `go-jira` and returns a `jira.Issue`.
 func (c *APIClient) GetIssue(issueKey string) *jira.Issue {
-	log.Printf("Fetching issue %s\n", issueKey)
 	i, r, err := c.Issue.Get(issueKey, &jira.GetQueryOptions{
 		Expand:       "names,schema,changelog",
 		FieldsByKeys: true,
 	})
 	if err != nil {
 		// TODO: instead of crashing, should handle the error and retry
-		log.Fatalln(fmt.Errorf("error in `getIssue`: %s -- response: %v", err, r))
+		log.Fatalln(fmt.Errorf("error in `GetIssue` for `%s`: %s -- response: %v", issueKey, err, r))
 	}
+	log.Printf("Fetched issue %s (updated: %s)\n", issueKey, time.Time(i.Fields.Updated))
 	return i
 }
 

--- a/jira/client/apiclient.go
+++ b/jira/client/apiclient.go
@@ -60,13 +60,13 @@ func (c *APIClient) SearchIssues(query string, issueKeys chan string) {
 // API using `go-jira` and returns a `jira.Issue`.
 func (c *APIClient) GetIssue(issueKey string) *jira.Issue {
 	log.Printf("Fetching issue %s\n", issueKey)
-	i, _, err := c.Issue.Get(issueKey, &jira.GetQueryOptions{
+	i, r, err := c.Issue.Get(issueKey, &jira.GetQueryOptions{
 		Expand:       "names,schema,changelog",
 		FieldsByKeys: true,
 	})
 	if err != nil {
 		// TODO: instead of crashing, should handle the error and retry
-		log.Fatalln(fmt.Errorf("error in `getIssue`: %s", err))
+		log.Fatalln(fmt.Errorf("error in `getIssue`: %s -- response: %v", err, r))
 	}
 	return i
 }

--- a/jira/sync.go
+++ b/jira/sync.go
@@ -56,7 +56,7 @@ func PerformIncrementalSync(c Client, store store.Store, poolSize int) {
 	}()
 
 	// Search issues (fetch issue keys)
-	restartFromUpdatedAt := store.GetMaxUpdatedAt(poolSize * 3)
+	restartFromUpdatedAt := store.GetRestartFromUpdatedAt(poolSize * 3)
 	q := fmt.Sprintf("updated > '%d/%d/%d %d:%d' ORDER BY updated ASC",
 		restartFromUpdatedAt.Year(),
 		restartFromUpdatedAt.Month(),

--- a/jira/sync.go
+++ b/jira/sync.go
@@ -56,13 +56,13 @@ func PerformIncrementalSync(c Client, store store.Store, poolSize int) {
 	}()
 
 	// Search issues (fetch issue keys)
-	maxUpdatedAt := store.GetMaxUpdatedAt()
-	q := fmt.Sprintf("updated > '%d/%d/%d %d:%d' ORDER BY created ASC",
-		maxUpdatedAt.Year(),
-		maxUpdatedAt.Month(),
-		maxUpdatedAt.Day(),
-		maxUpdatedAt.Hour(),
-		maxUpdatedAt.Minute())
+	restartFromUpdatedAt := store.GetMaxUpdatedAt(poolSize * 3)
+	q := fmt.Sprintf("updated > '%d/%d/%d %d:%d' ORDER BY updated ASC",
+		restartFromUpdatedAt.Year(),
+		restartFromUpdatedAt.Month(),
+		restartFromUpdatedAt.Day(),
+		restartFromUpdatedAt.Hour(),
+		restartFromUpdatedAt.Minute())
 	c.SearchIssues(q, issueKeys)
 	wg.Add(1) // Adding a job to wait for the processing of `issueKeys`
 
@@ -106,7 +106,7 @@ func PerformSync(c Client, store store.Store, poolSize int) {
 		}
 	}()
 
-	c.SearchIssues("order by created ASC", issueKeys)
+	c.SearchIssues("ORDER BY updated ASC", issueKeys)
 
 	// Wait until all fetches are done
 	wg.Wait()

--- a/jira/sync_test.go
+++ b/jira/sync_test.go
@@ -36,7 +36,7 @@ func TestPerformIncrementalSync(t *testing.T) {
 	c := client.NewMockClient(t)
 	s := store.NewMockStore(t)
 
-	s.ExpectGetMaxUpdatedAt().WillReturn(refTime)
+	s.ExpectGetRestartFromUpdatedAt().WillReturn(refTime)
 
 	// Perform a search with `updated > 'max issue_updated_at'`
 	expectedJiraQuery := fmt.Sprintf("updated > '%s' ORDER BY created ASC", timeAsStr(refTime))

--- a/store/mockstore.go
+++ b/store/mockstore.go
@@ -131,27 +131,27 @@ func (m *MockStore) ReplaceIssueStateAndEvents(ik string, is IssueState, ies []I
 	return ee.err
 }
 
-// GetMaxUpdatedAt returns the value specified with the
+// GetRestartFromUpdatedAt returns the value specified with the
 // expectation.
 //
-// To position an expectation, use `ExpectGetMaxUpdatedAt(..)`
-func (m *MockStore) GetMaxUpdatedAt(n int) *time.Time {
+// To position an expectation, use `ExpectGetRestartFromUpdatedAt(..)`
+func (m *MockStore) GetRestartFromUpdatedAt(n int) *time.Time {
 	e := m.popExpectation()
 	if e == nil {
-		m.Errorf("mock received `GetMaxUpdatedAt` but no expectation was set")
+		m.Errorf("mock received `GetRestartFromUpdatedAt` but no expectation was set")
 	}
-	ee, ok := e.(*ExpectedGetMaxUpdatedAt)
+	ee, ok := e.(*ExpectedGetRestartFromUpdatedAt)
 	if !ok {
-		m.Errorf("mock received `GetMaxUpdatedAt` but was expecting `%s`\n", e.Describe())
+		m.Errorf("mock received `GetRestartFromUpdatedAt` but was expecting `%s`\n", e.Describe())
 	}
 	// Implement the necessary mocking
 	return &ee.t
 }
 
-// ExpectGetMaxUpdatedAt sets an expectation on the
-// `GetMaxUpdatedAt` method.
-func (m *MockStore) ExpectGetMaxUpdatedAt() *ExpectedGetMaxUpdatedAt {
-	e := ExpectedGetMaxUpdatedAt{}
+// ExpectGetRestartFromUpdatedAt sets an expectation on the
+// `GetRestartFromUpdatedAt` method.
+func (m *MockStore) ExpectGetRestartFromUpdatedAt() *ExpectedGetRestartFromUpdatedAt {
+	e := ExpectedGetRestartFromUpdatedAt{}
 	m.expectations = append(m.expectations, &e)
 	return &e
 }
@@ -233,25 +233,25 @@ func (e *ExpectedReplaceIssueStateAndEvents) WillReturnError(err error) *Expecte
 	return e
 }
 
-// ExpectedGetMaxUpdatedAt
+// ExpectedGetRestartFromUpdatedAt
 // -----------------------
 
-// ExpectedGetMaxUpdatedAt represents an expectation for the
-// `GetMaxUpdatedAt` method.
-type ExpectedGetMaxUpdatedAt struct {
+// ExpectedGetRestartFromUpdatedAt represents an expectation for the
+// `GetRestartFromUpdatedAt` method.
+type ExpectedGetRestartFromUpdatedAt struct {
 	t time.Time
 }
 
 // WillReturn can be used to specify which value the
-// `GetMaxUpdatedAt` should return.
-func (e *ExpectedGetMaxUpdatedAt) WillReturn(t time.Time) *ExpectedGetMaxUpdatedAt {
+// `GetRestartFromUpdatedAt` should return.
+func (e *ExpectedGetRestartFromUpdatedAt) WillReturn(t time.Time) *ExpectedGetRestartFromUpdatedAt {
 	e.t = t
 	return e
 }
 
 // Describe describes the expectation
-func (e *ExpectedGetMaxUpdatedAt) Describe() string {
-	return fmt.Sprintf("GetMaxUpdatedAt")
+func (e *ExpectedGetRestartFromUpdatedAt) Describe() string {
+	return fmt.Sprintf("GetRestartFromUpdatedAt")
 }
 
 // Other

--- a/store/mockstore.go
+++ b/store/mockstore.go
@@ -135,7 +135,7 @@ func (m *MockStore) ReplaceIssueStateAndEvents(ik string, is IssueState, ies []I
 // expectation.
 //
 // To position an expectation, use `ExpectGetMaxUpdatedAt(..)`
-func (m *MockStore) GetMaxUpdatedAt() *time.Time {
+func (m *MockStore) GetMaxUpdatedAt(n int) *time.Time {
 	e := m.popExpectation()
 	if e == nil {
 		m.Errorf("mock received `GetMaxUpdatedAt` but no expectation was set")

--- a/store/pgstore.go
+++ b/store/pgstore.go
@@ -52,7 +52,7 @@ func (s *PGStore) ReplaceIssueStateAndEvents(k string, is IssueState, ies []Issu
 	return
 }
 
-// GetMaxUpdatedAt returns the `n`th value of `issue_updated_at` from
+// GetRestartFromUpdatedAt returns the `n`th value of `issue_updated_at` from
 // `jira_issues_states` in descending order.
 //
 // Instead of taking the maximum value, taking the `n`th one enables
@@ -61,7 +61,7 @@ func (s *PGStore) ReplaceIssueStateAndEvents(k string, is IssueState, ies []Issu
 // several goroutines, a crash or error may have processed newer issues
 // that the one it crashed for. `n` should thus be taken at least to
 // the number of goroutines fetching issues, even better a multiple.
-func (s *PGStore) GetMaxUpdatedAt(n int) *time.Time {
+func (s *PGStore) GetRestartFromUpdatedAt(n int) *time.Time {
 	var maxUpdatedAt time.Time
 	q := `
 	SELECT MIN(issue_updated_at)

--- a/store/store.go
+++ b/store/store.go
@@ -7,7 +7,7 @@ import (
 // Store is an interface for the application's store
 type Store interface {
 	ReplaceIssueStateAndEvents(k string, is IssueState, ies []IssueEvent) (err error)
-	GetMaxUpdatedAt(n int) *time.Time
+	GetRestartFromUpdatedAt(n int) *time.Time
 	CreateTables()
 	DropTables()
 }

--- a/store/store.go
+++ b/store/store.go
@@ -7,7 +7,7 @@ import (
 // Store is an interface for the application's store
 type Store interface {
 	ReplaceIssueStateAndEvents(k string, is IssueState, ies []IssueEvent) (err error)
-	GetMaxUpdatedAt() *time.Time
+	GetMaxUpdatedAt(n int) *time.Time
 	CreateTables()
 	DropTables()
 }

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -97,7 +97,7 @@ func TestPGStore_ReplaceIssueStateAndEvents(t *testing.T) {
 	}
 }
 
-func TestPGStore_GetMaxUpdatedAt(t *testing.T) {
+func TestPGStore_GetRestartFromUpdatedAt(t *testing.T) {
 	db, mock, err := sqlmock.New()
 	if err != nil {
 		t.Fatalf("an error '%s' was not expected when opening a stub database connection", err)
@@ -113,7 +113,7 @@ func TestPGStore_GetMaxUpdatedAt(t *testing.T) {
 	mock.ExpectQuery("SELECT MIN\\(issue_updated_at\\) FROM \\( SELECT issue_updated_at FROM jira_issues_states ORDER BY issue_updated_at DESC LIMIT \\$1 \\)").
 		WillReturnRows(rows)
 
-	r := s.GetMaxUpdatedAt(10)
+	r := s.GetRestartFromUpdatedAt(10)
 	if *r != timeV {
 		t.Errorf("unexpected result `%v`, expected `%v`\n", r, timeV)
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -110,10 +110,10 @@ func TestPGStore_GetMaxUpdatedAt(t *testing.T) {
 	rows := sqlmock.NewRows([]string{"max"}).
 		AddRow(timeV)
 
-	mock.ExpectQuery("SELECT MAX\\(issue_updated_at\\) FROM jira_issues_states").
+	mock.ExpectQuery("SELECT MIN\\(issue_updated_at\\) FROM \\( SELECT issue_updated_at FROM jira_issues_states ORDER BY issue_updated_at DESC LIMIT \\$1 \\)").
 		WillReturnRows(rows)
 
-	r := s.GetMaxUpdatedAt()
+	r := s.GetMaxUpdatedAt(10)
 	if *r != timeV {
 		t.Errorf("unexpected result `%v`, expected `%v`\n", r, timeV)
 	}


### PR DESCRIPTION
Changed implementation of initial and incremental syncs to enable continuing sync using incremental if initial failed before the end.

Ordering search issues result by `updated ASC` instead of `created` enable this. Securing possible race condition since multiple goroutines are used to fetch issues by going back 3 * number of goroutines when starting incremental sync (the restart offset is the (3 * number of goroutines)th value of `issue_updated_at` ordered descending).

Fixes #25 